### PR TITLE
Fix nixpkgs.config being ignored; sync brew; keep private paths out of git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
       - name: nix flake check
         run: nix flake check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: "9089"
+            runner: macos-15 # aarch64-darwin
+          - host: "9099"
+            runner: macos-13 # x86_64-darwin
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: nix flake check
+        run: nix flake check
+
+      - name: build darwinConfigurations.${{ matrix.host }}
+        run: nix build ".#darwinConfigurations.${{ matrix.host }}.system" -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,9 @@ concurrency:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - host: "9089"
-            runner: macos-15 # aarch64-darwin
-          - host: "9099"
-            runner: macos-13 # x86_64-darwin
-    runs-on: ${{ matrix.runner }}
+    # 9099 (x86_64-darwin) isn't covered: GitHub no longer offers free Intel macOS
+    # runners, only paid "larger runners" (macos-14-large etc).
+    runs-on: macos-15 # aarch64-darwin, matches host "9089"
     steps:
       - uses: actions/checkout@v4
 
@@ -28,5 +22,5 @@ jobs:
       - name: nix flake check
         run: nix flake check
 
-      - name: build darwinConfigurations.${{ matrix.host }}
-        run: nix build ".#darwinConfigurations.${{ matrix.host }}.system" -L
+      - name: build darwinConfigurations.9089
+        run: nix build ".#darwinConfigurations.9089.system" -L

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1763638478,
-        "narHash": "sha256-n/IMowE9S23ovmTkKX7KhxXC2Yq41EAVFR2FBIXPcT8=",
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "fbfdbaba008189499958a7aeb1e2c36ab10c067d",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.0.3",
+        "ref": "6.0.1",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766524813,
-        "narHash": "sha256-N/sxS27+t9nGvGWqwwAceSMW/Y5ddcypS/aiTnZ7ScA=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "c2b36207f2c396c79dbed9d40536db221bd4e363",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1762419028,
-        "narHash": "sha256-0xuottiNx6axHGySK7wYOKv1redGYSP4G33yKVBLlsI=",
+        "lastModified": 1768295518,
+        "narHash": "sha256-wGHbKt1NExphmMi96mdB0VEZKkat7gJ/4KTS616/xdU=",
         "ref": "refs/heads/master",
-        "rev": "7f2879c50494627bee69c4c764bb537cd77ae394",
-        "revCount": 29,
+        "rev": "bed7a431e68ab9202e526b338cc8ed2a132a5787",
+        "revCount": 31,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/philingood/dotfiles.git"
@@ -133,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766682973,
-        "narHash": "sha256-GKO35onS711ThCxwWcfuvbIBKXwriahGqs+WZuJ3v9E=",
+        "lastModified": 1781989573,
+        "narHash": "sha256-npfH7Zv7t1akX/ArqCNro4zU4ViPlghLaPnbEfHbCxk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "91cdb0e2d574c64fae80d221f4bf09d5592e9ec2",
+        "rev": "78e7d8b13ecd7f5256a5c11ce216876164099d9f",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1766737810,
-        "narHash": "sha256-TSk6lumiM8e2JAkDuE//WipPK48e0G7dlySBmoch0HY=",
+        "lastModified": 1783070075,
+        "narHash": "sha256-A6ixnopk9NakK6RmcoFjYywbFLvlw61D9Y3j7XI1XU0=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "76f6e7955dd27bdedd4b32bdfe497115ab7eee7d",
+        "rev": "16c949d09107246545bf8faca222fba6ad56e696",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1766739231,
-        "narHash": "sha256-kFJxcM/T1zXRK6tPHaw7LLcO0hraQxUnhOyVUxaYGZ4=",
+        "lastModified": 1782031272,
+        "narHash": "sha256-kM55rK24Y6+mIixPQigam6l6kxcw8/muDmUG839dZa8=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "de76dc83e9a14886ffe25641d2a044683aca343b",
+        "rev": "169099025801534b9f2117390d1a6b3c04b2d70e",
         "type": "github"
       },
       "original": {
@@ -214,7 +214,7 @@
     "naersk": {
       "inputs": {
         "fenix": "fenix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1763384566,
@@ -235,11 +235,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1764473698,
-        "narHash": "sha256-C91gPgv6udN5WuIZWNehp8qdLqlrzX6iF/YyboOj6XI=",
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "6a8ab60bfd66154feeaa1021fc3b32684814a62a",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
         "type": "github"
       },
       "original": {
@@ -249,12 +249,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1766568855,
-        "narHash": "sha256-UXVtN77D7pzKmzOotFTStgZBqpOcf8cO95FcupWp4Zo=",
+        "lastModified": 1781622756,
+        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c5db9569ac9cc70929c268ac461f4003e3e5ca80",
+        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
         "type": "github"
       },
       "original": {
@@ -266,59 +269,56 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
-        "type": "github"
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable-darwin": {
       "locked": {
-        "lastModified": 1735564410,
-        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "lastModified": 1782904953,
+        "narHash": "sha256-ESJ4VgytmAt+98YLM8466luln4HyEZ9Q36b9+Bb4P5w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "rev": "0921fdb3e13e40fe25fbc52b89661a9d6d32ac68",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-24.05-darwin",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1766653575,
-        "narHash": "sha256-TPgxCS7+hWc4kPhzkU5dD2M5UuPhLuuaMNZ/IpwKQvI=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3c1016e6acd16ad96053116d0d3043029c9e2649",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -329,6 +329,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1752077645,
         "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
@@ -379,7 +395,7 @@
         "homebrew-services": "homebrew-services",
         "nix-homebrew": "nix-homebrew",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-stable-darwin": "nixpkgs-stable-darwin",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,8 @@
   description = "Hacker`s flake";
   inputs = {
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
-    ## TODO: not sure if it matters, but probably worth threading -darwin version through on darwin builds
-    nixpkgs-stable-darwin.url = "github:nixos/nixpkgs/nixpkgs-24.05-darwin";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs-stable-darwin.url = "github:nixos/nixpkgs/nixpkgs-25.11-darwin";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable"; # defaulting to unstable these days
 
     flake-compat = {
@@ -36,6 +35,10 @@
     homebrew-bundle.flake = false;
     homebrew-services.url = "github:homebrew/homebrew-services";
     homebrew-services.flake = false;
+    # Fallback tap for zathura, in case pkgs.stable.zathura (home-manager) ever breaks too.
+    # Commented out along with its uses in nix-homebrew.taps below and in modules/darwin/brew.nix.
+    # homebrew-zathura-tap.url = "github:homebrew-zathura/homebrew-zathura";
+    # homebrew-zathura-tap.flake = false;
     dotfiles = {
       type = "git";
       url = "https://github.com/philingood/dotfiles.git";
@@ -55,18 +58,6 @@
     , nix-homebrew
     , ...
     }: let
-    mkPkgs = system:
-      import nixpkgs {
-        inherit system;
-        inherit
-          (import ./modules/overlays.nix {
-            inherit inputs nixpkgs-unstable nixpkgs-stable nixpkgs-stable-darwin;
-          })
-          overlays
-          ;
-        config = import ./config.nix;
-      };
-
     mkHome = username: modules: {
       home-manager = {
         useGlobalPkgs = true;
@@ -85,7 +76,6 @@
         {
           "9089" = darwin.lib.darwinSystem {
             system = "aarch64-darwin";
-            pkgs = import nixpkgs { system = "aarch64-darwin"; };
             specialArgs = {
               inherit inputs nixpkgs-stable nixpkgs-stable-darwin nixpkgs-unstable username;
             };
@@ -104,6 +94,7 @@
                     "homebrew/homebrew-cask" = homebrew-cask;
                     "homebrew/homebrew-bundle" = homebrew-bundle;
                     "homebrew/homebrew-services" = homebrew-services;
+                    # "homebrew-zathura/homebrew-zathura" = homebrew-zathura-tap; # fallback, see input above
                   };
                   # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
                   mutableTaps = false;
@@ -120,7 +111,6 @@
           };
           "9099" = darwin.lib.darwinSystem {
             system = "x86_64-darwin";
-            pkgs = import nixpkgs { system = "x86_64-darwin"; };
             specialArgs = {
               inherit inputs nixpkgs-stable nixpkgs-stable-darwin nixpkgs-unstable username;
             };

--- a/modules/darwin/brew.nix
+++ b/modules/darwin/brew.nix
@@ -17,12 +17,14 @@
       "homebrew/bundle"
       "homebrew/cask"
       "homebrew/services"
+      # "homebrew-zathura/zathura" # fallback tap for zathura, in case pkgs.stable.zathura (home-manager) ever breaks too.
+      # Also needs registering in flake.nix's nix-homebrew.taps to reactivate (mutableTaps = false there).
     ];
     casks = [
-      "alt-tab"
-      "anydesk"
+      #"alt-tab"
+      #"anydesk"
       "appcleaner"
-      "arc"
+      #"arc"
       "audacity"
       "avidemux"
       "betterdisplay"
@@ -32,34 +34,37 @@
       # "citrix-workspace"
       "chatgpt"
       # "choosy" # multi-browser url launch selector; see also https://github.com/johnste/finicky
+      "claude"
+      "claude-code"
       "cursor"
       "dbeaver-community"
       "discord"
       #"docker" # removed in favor of colima + docker cli
       "balenaetcher"  # tool for make bootable usb drive
-      "firefox@developer-edition"
-      "freetube" # trying out private youtube browsing after reading about how toxic their algo is
+      #"firefox@developer-edition"
+      "freecad"
+      #"freetube" # trying out private youtube browsing after reading about how toxic their algo is
       "ghostty"
-      "github"
+      #"github"
       "gpg-suite"
       "hammerspoon"
       "heroic"
       "homerow"
-      "httpie-desktop"
+      #"httpie-desktop"
       # "hugin" # does not work on apple silicon
       "inkscape"
-      "istat-menus"
+      #"istat-menus"
       "iterm2"
-      "jellyfin-media-player"
+      "font-liberation"
+      #"jellyfin-media-player"
       "karabiner-elements"
-      "kitty"
+      #"kitty"
       "keycastr"
       "librewolf"
       "lm-studio"
-      "macfuse"
+      # "macfuse"
       # "mactex-no-gui"
       "mathpix-snipping-tool"
-      "stolendata-mpv"
       "nextcloud-vfs"
       "nextcloud-talk"
       "ngrok"
@@ -67,12 +72,12 @@
       "obs" # TODO: move to nix version obs-studio when not broke
       "obsidian"
       # "onyx" #TODO: enable when brew will support macOS 26
-      "openlens"
+      #"openlens"
       "openvpn-connect"
       "orbstack"
-      "outline-manager"
+      #"outline-manager"
       "qflipper"
-      "qutebrowser" # TODO: move over when it builds on arm64 darwin
+      #"qutebrowser" # TODO: move over when it builds on arm64 darwin
       "qlmarkdown"
       "qlstephen"
       "qlvideo"
@@ -91,17 +96,11 @@
       #"topaz-photo-ai"
       #"topaz-video-ai"
       "tor-browser"
-      "tradingview"
-      "transmission"
-      # "$HOME/nix-config/modules/darwin/vscode.rb" # FIXME: this doesn't work. I want to use specific version of vscode. See https://code.visualstudio.com/docs/supporting/faq#_previous-release-versions
+      #"tradingview"
+      #"transmission"
       "whisky"
       "yandex-music"
-
-      # Keeping the next three together as they act in concert and are made by the same guy
-      # FIXME: This is PAY TO PLAY. So i need an ultimate solution!
-      # "kindavim" # ctrl-esc allows you to control an input area as if in vim normal mode
-      # "scrolla" # use vim commands to select scroll areas and scroll
-      # "wooshy" # use cmd-shift-space to bring up search to select interface elements in current app
+      # "zotero"
     ];
     masApps = {
       # "Apple Configurator 2" = 1037126344;
@@ -132,6 +131,7 @@
       "chkrootkit"
       "choose-gui"
       "ddcctl"
+      "goreleaser"
       "hashcat"
       "helm"
       "hydra"
@@ -140,12 +140,21 @@
       "node"
       "p0f"
       "qt"
+      "qwen-code"
       "recon-ng"
+      "spoofdpi"
       "teleport"
       "terminal-notifier"
+      "tesseract"
+      "tesseract-lang"
+      "tree-sitter-cli"
+      "typst"
+      "uv"
       "whisper-cpp"
       "whisperkit-cli"
       "yt-dlp"
+      # "homebrew-zathura/zathura/zathura" # fallback for zathura, see taps above
+      # "homebrew-zathura/zathura/zathura-pdf-mupdf"
     ];
   };
 }

--- a/modules/darwin/core.nix
+++ b/modules/darwin/core.nix
@@ -3,7 +3,21 @@
   config,
   pkgs,
   ...
-}: {
+}: let
+  nixpkgsConfig = import ../../config.nix;
+
+  # Access a package from the pinned stable channel via pkgs.stable.<name>,
+  # for when a package is broken on the unstable channel we track by default.
+  stableOverlay = final: prev: {
+    stable = import inputs.nixpkgs-stable-darwin {
+      inherit (final.stdenv.hostPlatform) system;
+      config = nixpkgsConfig;
+    };
+  };
+in {
+  nixpkgs.config = nixpkgsConfig;
+  nixpkgs.overlays = [stableOverlay];
+
   # environment setup
   environment = {
     # loginShell = pkgs.zsh;

--- a/modules/darwin/preferences.nix
+++ b/modules/darwin/preferences.nix
@@ -1,4 +1,13 @@
-_: {
+_: let
+  # Machine-local overrides that shouldn't be committed (e.g. paths containing a private
+  # domain/email). Not part of the repo, so it's invisible to git entirely. Requires
+  # --impure (see the dwsw alias in modules/home-manager/default.nix).
+  localConfigPath = /Users/hacker/.config/nix-config-local.nix;
+  localConfig =
+    if builtins.pathExists localConfigPath
+    then import localConfigPath
+    else {};
+in {
   system.primaryUser = "hacker";
   system.defaults = {
     #
@@ -142,7 +151,7 @@ _: {
         askForPasswordDelay = 0;
       };
       "com.apple.screencapture" = {
-        location = "~/Pictures/Screenshots";
+        location = localConfig.screenshotLocation or "~/Pictures/Screenshots";
         type = "png";
       };
       "com.apple.ActivityMonitor" = {

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -348,7 +348,7 @@ in
         #checktype = "mdls -name kMDItemContentType -name kMDItemContentTypeTree -name kMDItemKind";
         # brew update should no longer be needed; and brew upgrade should just happen, I think, but I might need to specify greedy per package
         #dwupdate = "pushd ~/.config/nixpkgs ; nix flake update ; popd ; dwswitchx ; dwshowupdates; popd";
-        dwsw = "sudo darwin-rebuild switch --flake ~/nix-config/.#$(hostname -s)";
+        dwsw = "sudo darwin-rebuild switch --flake ~/nix-config/.#$(hostname -s) --impure"; # --impure: reads ~/.config/nix-config-local.nix for machine-local overrides
         dwclean = "pushd ~; sudo nix-env --delete-generations +7 --profile /nix/var/nix/profiles/system; sudo nix-collect-garbage --delete-older-than 30d ; nix store optimise ; popd";
         #dwupcheck = "pushd ~/.config/nixpkgs ; nix flake update ; darwin-rebuild build --flake ~/.config/nixpkgs/.#$(hostname -s) && nix store diff-closures /nix/var/nix/profiles/system ~/.config/nixpkgs/result; popd"; # todo: prefer nvd?
         # i use the zsh shell out in case anyone blindly copies this into their bash or fish profile since syntax is zsh specific

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -48,7 +48,10 @@ let
       pandoc # for lf preview
       poppler-utils # for pdf2text in lf
       sourceHighlight # for lf preview
-      zathura
+      # unstable zathura fails to build on darwin (appstream is broken there); pulling from
+      # nixpkgs-stable-darwin instead via the pkgs.stable overlay (modules/darwin/core.nix).
+      # Fallback if this ever breaks too: brew version, commented out in modules/darwin/brew.nix.
+      stable.zathura
 
       ## network
       aria2 # cli downloader
@@ -56,7 +59,7 @@ let
       gping
       hostname
       inetutils
-      spoofdpi
+      # spoofdpi
       static-web-server # serve local static files
       trippy # mtr alternative
       xh # rust version of httpie / better curl
@@ -80,7 +83,7 @@ let
       neovim
       ollama
       onefetch
-      python312Packages.conda
+      # python312Packages.conda
       tldr
       tmux
 
@@ -191,8 +194,8 @@ in
         "\C-n":"cd ..\n"
         set editing-mode vi
     '';
-    ".config/ghostty/config".source = config.lib.file.mkOutOfStoreSymlink "${inputs.dotfiles.outPath}/.config/ghostty/config";
-    ".config/karabiner/karabiner.json".source = config.lib.file.mkOutOfStoreSymlink "${inputs.dotfiles.outPath}/.config/karabiner/karabiner.json";
+    # ghostty and karabiner configs are managed via stow from ~/dotfiles instead (frequently
+    # live-edited / GUI-driven, so nix's frozen flake-locked copy kept fighting the real files).
     # "Library/Application Support/Cursor/User/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${inputs.dotfiles.outPath}/Library/Application Support/Cursor/User/settings.json";
   };
   programs.bat = {
@@ -346,10 +349,10 @@ in
         # brew update should no longer be needed; and brew upgrade should just happen, I think, but I might need to specify greedy per package
         #dwupdate = "pushd ~/.config/nixpkgs ; nix flake update ; popd ; dwswitchx ; dwshowupdates; popd";
         dwsw = "sudo darwin-rebuild switch --flake ~/nix-config/.#$(hostname -s)";
-        #dwclean = "pushd ~; sudo nix-env --delete-generations +7 --profile /nix/var/nix/profiles/system; sudo nix-collect-garbage --delete-older-than 30d ; nix store optimise ; popd";
+        dwclean = "pushd ~; sudo nix-env --delete-generations +7 --profile /nix/var/nix/profiles/system; sudo nix-collect-garbage --delete-older-than 30d ; nix store optimise ; popd";
         #dwupcheck = "pushd ~/.config/nixpkgs ; nix flake update ; darwin-rebuild build --flake ~/.config/nixpkgs/.#$(hostname -s) && nix store diff-closures /nix/var/nix/profiles/system ~/.config/nixpkgs/result; popd"; # todo: prefer nvd?
         # i use the zsh shell out in case anyone blindly copies this into their bash or fish profile since syntax is zsh specific
-        #dwshowupdates = ''
+        dwshowupdates = ''
           #zsh -c "nix store diff-closures /nix/var/nix/profiles/system-*-link(om[2]) /nix/var/nix/profiles/system-*-link(om[1])"'';
       }
       // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {


### PR DESCRIPTION
## Summary
- `nixpkgs.config` (incl. `allowUnfree`) was silently ignored because `pkgs=` was passed directly to `darwinSystem`, bypassing all `nixpkgs.*` options — unfree vim plugins failed to build. Fixed by dropping the explicit `pkgs=` and the dead `mkPkgs` helper, and setting `nixpkgs.config`/`nixpkgs.overlays` as module options in `core.nix` instead.
- Added a `pkgs.stable` overlay (via `nixpkgs-stable-darwin`) so individual packages can be pulled from the stable channel when unstable breaks, and bumped the stable pin from the dead `24.05` branch to `25.11`.
- `zathura` now comes from `pkgs.stable` (unstable's build is broken there — `appstream` fails on darwin).
- Homebrew: reconciled declared config against what's actually installed on the machine — added `lm-studio`, `goreleaser`; dropped dead/unused casks (`macfuse`, `freetube`, `github`, `istat-menus`, `kitty`, `openlens`, `outline-manager`, `qutebrowser`, `tradingview`, `transmission`).
- Stopped managing `.config/ghostty/config` and `.config/karabiner.json` through home-manager — both are frequently live-edited (karabiner via its own GUI) and kept fighting the frozen flake-locked copy; will be managed via stow from `~/dotfiles` instead.
- Screenshot location (contained a personal domain) now reads from an optional, never-committed `~/.config/nix-config-local.nix`, falling back to `~/Pictures/Screenshots` in the repo. Requires `--impure`, added to the `dwsw` alias.

## Test plan
- [x] `darwin-rebuild build --flake .#9089` succeeds
- [x] `darwin-rebuild switch --flake .#9089 --impure` applied cleanly on the live machine (brew bundle installed/removed as declared, home-manager activated)
- [x] Verified `pkgs.stable.hello`/`pkgs.stable.zathura` resolve correctly
- [x] Verified private screenshot path resolves from the local override file, public repo shows the safe default